### PR TITLE
typo: @code{\"SS\"}。→@code{\"i\\u0307\"} (…)。，(@code{\\\"i\\\\u0307\\\"}→@code{\"i\\u0307\"})

### DIFF
--- a/lispref/nonascii.texi.po
+++ b/lispref/nonascii.texi.po
@@ -1030,7 +1030,7 @@ msgstr "special-lowercase"
 #. type: table
 #: original_texis/nonascii.texi:642
 msgid "Corresponds to Unicode language- and context-independent special lower-casing rules.  The value of this property is a string (which may be empty).  For example mapping for U+0130 @sc{latin capital letter i with dot above} the value is @code{\"i\\u0307\"} (i.e. 2-character string consisting of @sc{latin small letter i} followed by U+0307 @sc{combining dot above}).  For characters with no special mapping, the value is @code{nil} which means @code{lowercase} property needs to be consulted instead."
-msgstr "Unicodeの言語やコンテキストに依存しない特別な小文字caseルールに対応する。このプロパティの値は文字列(空も可)。たとえばU+0130 @sc{latin capital letter i with dot above}にたいするマッピングは@code{\"SS\"}。特別なマッピングのない文字にたいする値は@code{nil} (かわりに@code{lowercase}プロパティの照会が必要なことを意味する)。"
+msgstr "Unicodeの言語やコンテキストに依存しない特別な小文字caseルールに対応する。このプロパティの値は文字列(空も可)。たとえばU+0130 @sc{latin capital letter i with dot above}にたいするマッピングは@code{\"i\\u0307\"} (すなわち@sc{latin small letter i}の後にU+0307 @sc{combining dot above}が続くことによって構成される2文字の文字列)。特別なマッピングのない文字にたいする値は@code{nil} (かわりに@code{lowercase}プロパティの照会が必要なことを意味する)。"
 
 #. type: item
 #: original_texis/nonascii.texi:643


### PR DESCRIPTION
emacs-28ブランチ，emacs-29ブランチへの修正はバックスラッシュが多いと思います．