### PR TITLE
「どちらも整数であるかどちらも浮動小数であるか」への修正，「は、」削除，「(訳注:同じ値の場合には)」の追記

### DIFF
--- a/lispref/help.texi.po
+++ b/lispref/help.texi.po
@@ -732,7 +732,7 @@ msgstr "\\="
 #. type: table
 #: original_texis/help.texi:368
 msgid "quotes the following character and is discarded; thus, @samp{\\=`} puts @samp{`} into the output, @samp{\\=\\[} puts @samp{\\[} into the output, and @samp{\\=\\=} puts @samp{\\=} into the output."
-msgstr "これは後続の文字をクォートして無効にする。したがって@samp{\\=\\[}は@samp{\\[}、@samp{\\=\\=}は@samp{\\=}を出力する。"
+msgstr "これは後続の文字をクォートして無効にする。したがって@samp{\\=`}は@samp{`}、@samp{\\=\\[}は@samp{\\[}、@samp{\\=\\=}は@samp{\\=}を出力する。"
 
 #. type: item
 #: original_texis/help.texi:369

--- a/lispref/nonascii.texi.po
+++ b/lispref/nonascii.texi.po
@@ -1030,7 +1030,7 @@ msgstr "special-lowercase"
 #. type: table
 #: original_texis/nonascii.texi:642
 msgid "Corresponds to Unicode language- and context-independent special lower-casing rules.  The value of this property is a string (which may be empty).  For example mapping for U+0130 @sc{latin capital letter i with dot above} the value is @code{\"i\\u0307\"} (i.e. 2-character string consisting of @sc{latin small letter i} followed by U+0307 @sc{combining dot above}).  For characters with no special mapping, the value is @code{nil} which means @code{lowercase} property needs to be consulted instead."
-msgstr "Unicodeの言語やコンテキストに依存しない特別な小文字caseルールに対応する。このプロパティの値は文字列(空も可)。たとえばU+0130 @sc{latin capital letter i with dot above}にたいするマッピングは@code{\"SS\"}。特別なマッピングのない文字にたいする値は@code{nil} (かわりに@code{lowercase}プロパティの照会が必要なことを意味する)。"
+msgstr "Unicodeの言語やコンテキストに依存しない特別な小文字caseルールに対応する。このプロパティの値は文字列(空も可)。たとえばU+0130 @sc{latin capital letter i with dot above}にたいするマッピングは@code{\"i\\u0307\"} (すなわち@sc{latin small letter i}の後にU+0307 @sc{combining dot above}が続くことによって構成される2文字の文字列)。特別なマッピングのない文字にたいする値は@code{nil} (かわりに@code{lowercase}プロパティの照会が必要なことを意味する)。"
 
 #. type: item
 #: original_texis/nonascii.texi:643

--- a/lispref/numbers.texi.po
+++ b/lispref/numbers.texi.po
@@ -810,7 +810,7 @@ msgstr "Emacs Lispでは2つのfixnumが数値的に等しければ同一のLisp
 #. type: Plain text
 #: original_texis/numbers.texi:428
 msgid "Sometimes it is useful to compare numbers with @code{eql} or @code{equal}, which treat two numbers as equal if they have the same data type (both integers, or both floating point) and the same value.  By contrast, @code{=} can treat an integer and a floating-point number as equal.  @xref{Equality Predicates}."
-msgstr "数の比較において、2つの数が同じデータ型(どちらも整数か浮動小数)では、同じ値の場合は等しい数として扱う@code{eql}や@code{equal}のほうが便利なときもあります。対照的に@code{=}は整数と浮動小数点数を等しい数と扱うことができます。@ref{Equality Predicates}を参照してください。"
+msgstr "数の比較において、2つの数が同じデータ型(どちらも整数であるかどちらも浮動小数であるか)で同じ値の場合は等しい数として扱う@code{eql}や@code{equal}のほうが便利なときもあります。対照的に@code{=}は整数と浮動小数点数を(訳注:同じ値の場合には)等しい数と扱うことができます。@ref{Equality Predicates}を参照してください。"
 
 #. type: Plain text
 #: original_texis/numbers.texi:433

--- a/lispref/objects.texi.po
+++ b/lispref/objects.texi.po
@@ -2737,7 +2737,7 @@ msgstr "@dfn{バッファー(buffer)}とは、編集されるテキストを保�
 #. type: Plain text
 #: original_texis/objects.texi:1567
 msgid "The contents of a buffer are much like a string, but buffers are not used like strings in Emacs Lisp, and the available operations are different.  For example, you can insert text efficiently into an existing buffer, altering the buffer's contents, whereas inserting text into a string requires concatenating substrings, and the result is an entirely new string object."
-msgstr "バッファーの内容は文字列によく似ていますが、バッファーはEmacs Lispの文字列と同じようには使用されず、利用可能な操作は異なります。文字列にテキストを挿入するためには部分文字列の結合が必要で、結果は完全に新しい文字列オブジェクトなのるのにたいして、バッファーでは既存のバッファーに効率的にテキストを挿入してバッファーの内容を変更できます。"
+msgstr "バッファーの内容は文字列によく似ていますが、バッファーはEmacs Lispの文字列と同じようには使用されず、利用可能な操作は異なります。たとえば文字列にテキストを挿入するためには部分文字列の結合が必要であり、結果は完全に新しい文字列オブジェクトなのるのにたいして、バッファーでは既存のバッファーに効率的にテキストを挿入してバッファーの内容を変更できます。"
 
 #. type: Plain text
 #: original_texis/objects.texi:1571

--- a/lispref/objects.texi.po
+++ b/lispref/objects.texi.po
@@ -2420,7 +2420,7 @@ msgstr "primitive function"
 #. type: Plain text
 #: original_texis/objects.texi:1413
 msgid "A @dfn{primitive function} is a function callable from Lisp but written in the C programming language.  Primitive functions are also called @dfn{subrs} or @dfn{built-in functions}.  (The word ``subr'' is derived from ``subroutine''.)  Most primitive functions evaluate all their arguments when they are called.  A primitive function that does not evaluate all its arguments is called a @dfn{special form} (@pxref{Special Forms})."
-msgstr "@dfn{プリミティブ関数(primitive function)}とは、Cプログラミング言語で記述されたLispから呼び出せる関数です。プリミティブ関数は@dfn{subrs}や@dfn{ビルトイン関数(built-in functions)}とも呼ばれます(単語``subr''は``サブルーチン(subroutine)''が由来)。ほとんどのプリミティブ関数ハ、呼び出されたときニすべての引数を評価します。すべての引数を評価しないプリミティブ関数は@dfn{スペシャルフォーム(special form)}と呼ばれます(@ref{Special Forms}を参照)。"
+msgstr "@dfn{プリミティブ関数(primitive function)}とは、Cプログラミング言語で記述されたLispから呼び出せる関数です。プリミティブ関数は@dfn{subrs}や@dfn{ビルトイン関数(built-in functions)}とも呼ばれます(単語``subr''は``サブルーチン(subroutine)''が由来)。ほとんどのプリミティブ関数は、呼び出されたときにすべての引数を評価します。すべての引数を評価しないプリミティブ関数は@dfn{スペシャルフォーム(special form)}と呼ばれます(@ref{Special Forms}を参照)。"
 
 #. type: Plain text
 #: original_texis/objects.texi:1421

--- a/lispref/objects.texi.po
+++ b/lispref/objects.texi.po
@@ -960,7 +960,7 @@ msgstr "?Q @result{} 81     ?q @result{} 113\n"
 #. type: Plain text
 #: original_texis/objects.texi:377
 msgid "You can use the same syntax for punctuation characters.  However, if the punctuation character has a special syntactic meaning in Lisp, you must quote it with a @samp{\\}.  For example, @samp{?\\(} is the way to write the open-paren character.  Likewise, if the character is @samp{\\}, you must use a second @samp{\\} to quote it: @samp{?\\\\}."
-msgstr "区切り文字(punctuation characters)にも同じ構文を使用できますが、区切り文字がLispで特別な意味をもつ場合には@samp{\\\\}でクォートしなければなりません。たとえば@samp{?\\\\(}が開カッコを記述する方法であり、同様に文字が@samp{\\}なら、@samp{?\\\\}のようにクォートするために2つ目の@samp{\\}を使用しなければなりません。"
+msgstr "区切り文字(punctuation characters)にも同じ構文を使用できますが、区切り文字がLispで特別な意味をもつ場合には@samp{\\}でクォートしなければなりません。たとえば@samp{?\\(}が開カッコを記述する方法であり、同様に文字が@samp{\\}なら、@samp{?\\\\}のようにクォートするために2つ目の@samp{\\}を使用しなければなりません。"
 
 #. type: cindex
 #: original_texis/objects.texi:378

--- a/lispref/searching.texi.po
+++ b/lispref/searching.texi.po
@@ -885,7 +885,7 @@ msgstr "バッファーではなく文字列とマッチする際には、@samp{
 #. type: table
 #: original_texis/searching.texi:524
 msgid "For historical compatibility reasons, @samp{$} can be used only at the end of the regular expression, or before @samp{\\)} or @samp{\\|}."
-msgstr "歴史的な互換性という理由により@samp{$}は正規表現の先頭、または@samp{\\(}、@samp{\\(?:}、@samp{\\|}の前でのみ使用できる。"
+msgstr "歴史的な互換性という理由により@samp{$}は正規表現の終端、または@samp{\\)}、@samp{\\|}の前でのみ使用できる。"
 
 #. type: samp{#1}
 #: original_texis/searching.texi:525


### PR DESCRIPTION
emacs-28ブランチ，emacs-29ブランチへの変更と同じです．