### PR TITLE
「を」追記「下方」削除「その」追記，「先行ビットは…丸められる。」→「先頭ビットは…等価である。」

### DIFF
--- a/lispref/help.texi.po
+++ b/lispref/help.texi.po
@@ -732,7 +732,7 @@ msgstr "\\="
 #. type: table
 #: original_texis/help.texi:368
 msgid "quotes the following character and is discarded; thus, @samp{\\=`} puts @samp{`} into the output, @samp{\\=\\[} puts @samp{\\[} into the output, and @samp{\\=\\=} puts @samp{\\=} into the output."
-msgstr "これは後続の文字をクォートして無効にする。したがって@samp{\\=\\[}は@samp{\\[}、@samp{\\=\\=}は@samp{\\=}を出力する。"
+msgstr "これは後続の文字をクォートして無効にする。したがって@samp{\\=`}は@samp{`}、@samp{\\=\\[}は@samp{\\[}、@samp{\\=\\=}は@samp{\\=}を出力する。"
 
 #. type: item
 #: original_texis/help.texi:369

--- a/lispref/nonascii.texi.po
+++ b/lispref/nonascii.texi.po
@@ -1030,7 +1030,7 @@ msgstr "special-lowercase"
 #. type: table
 #: original_texis/nonascii.texi:642
 msgid "Corresponds to Unicode language- and context-independent special lower-casing rules.  The value of this property is a string (which may be empty).  For example mapping for U+0130 @sc{latin capital letter i with dot above} the value is @code{\"i\\u0307\"} (i.e. 2-character string consisting of @sc{latin small letter i} followed by U+0307 @sc{combining dot above}).  For characters with no special mapping, the value is @code{nil} which means @code{lowercase} property needs to be consulted instead."
-msgstr "Unicodeの言語やコンテキストに依存しない特別な小文字caseルールに対応する。このプロパティの値は文字列(空も可)。たとえばU+0130 @sc{latin capital letter i with dot above}にたいするマッピングは@code{\"SS\"}。特別なマッピングのない文字にたいする値は@code{nil} (かわりに@code{lowercase}プロパティの照会が必要なことを意味する)。"
+msgstr "Unicodeの言語やコンテキストに依存しない特別な小文字caseルールに対応する。このプロパティの値は文字列(空も可)。たとえばU+0130 @sc{latin capital letter i with dot above}にたいするマッピングは@code{\"i\\u0307\"} (すなわち@sc{latin small letter i}の後にU+0307 @sc{combining dot above}が続くことによって構成される2文字の文字列)。特別なマッピングのない文字にたいする値は@code{nil} (かわりに@code{lowercase}プロパティの照会が必要なことを意味する)。"
 
 #. type: item
 #: original_texis/nonascii.texi:643

--- a/lispref/numbers.texi.po
+++ b/lispref/numbers.texi.po
@@ -756,7 +756,7 @@ msgstr "natural numbers"
 #. type: defun
 #: original_texis/numbers.texi:386
 msgid "This predicate (whose name comes from the phrase ``natural number'')  tests to see whether its argument is a nonnegative integer, and returns @code{t} if so, @code{nil} otherwise.  0 is considered non-negative."
-msgstr "この述語は引数が正の整数かどうかをテストしてもしそうなら@code{t}、それ以外は@code{nil}をリターンする(名前は``natural numberl: 自然数''が由来)。0は整数と判断される。"
+msgstr "この述語は引数が正の整数かどうかをテストしてもしそうなら@code{t}、それ以外は@code{nil}をリターンする(名前は``natural number: 自然数''が由来)。0は負でないと判断される。"
 
 #. type: findex
 #: original_texis/numbers.texi:387

--- a/lispref/numbers.texi.po
+++ b/lispref/numbers.texi.po
@@ -459,23 +459,23 @@ msgstr "integer-width"
 #. type: defvar
 #: original_texis/numbers.texi:204
 msgid "The value of this variable is a nonnegative integer that controls whether Emacs signals a range error when a large integer would be calculated.  Integers with absolute values less than"
-msgstr "この変数の値は大きな整数えお計算時にEmacsが範囲エラー(range error)をシグナルするかどうかを制御する負ではない整数。絶対値が"
+msgstr "この変数の値は大きな整数の計算時にEmacsが範囲エラー(range error)をシグナルするかどうかを制御する負ではない整数。絶対値が"
 
 #. type: ifnottex
 #: original_texis/numbers.texi:206
 msgid "2**@var{n},"
-msgstr "2**@var{n},"
+msgstr "2**@var{n}"
 
 #. type: tex
 #: original_texis/numbers.texi:209
 #, no-wrap
 msgid "@math{2^{n}},\n"
-msgstr "@math{2^{n}},\n"
+msgstr "@math{2^{n}}\n"
 
 #. type: defvar
 #: original_texis/numbers.texi:215
 msgid "where @var{n} is this variable's value, do not signal a range error.  Attempts to create larger integers typically signal a range error, although there might be no signal if a larger integer can be created cheaply.  Setting this variable to a large number can be costly if a computation creates huge integers."
-msgstr "(@var{n}はこの変数の値)が小さい整数は範囲エラーをシグナルしない。大きい整数を簡単に作成できればエラーがシグナルされない場合もあるが、通常は大きな整数の作成を試みると範囲エラーをシグナルする。この変数に大きな数値を設定すると、巨大な整数の計算にコストを要する可能性がある。"
+msgstr "(@var{n}はこの変数の値)より小さい整数の時は範囲エラーをシグナルしない。大きい整数を簡単に作成できればエラーがシグナルされない場合もあるが、通常は大きな整数の作成を試みると範囲エラーをシグナルする。この変数に大きな数値を設定すると、巨大な整数の計算にコストを要する可能性がある。"
 
 #. type: section
 #: original_texis/numbers.texi:218

--- a/lispref/numbers.texi.po
+++ b/lispref/numbers.texi.po
@@ -1704,12 +1704,12 @@ msgstr "@math{2^{count}}\n"
 #. type: defun
 #: original_texis/numbers.texi:894
 msgid "and then converts the result to an integer by rounding downward, toward minus infinity."
-msgstr "乗じてから下方、負の無限大に向かって丸めることにより結果を変換する。"
+msgstr "を乗じてから、負の無限大に向かって丸めることによりその結果を変換する。"
 
 #. type: defun
 #: original_texis/numbers.texi:901
 msgid "Here are examples of @code{ash}, shifting a pattern of bits one place to the left and to the right.  These examples show only the low-order bits of the binary pattern; leading bits all agree with the highest-order bit shown.  As you can see, shifting left by one is equivalent to multiplying by two, whereas shifting right by one is equivalent to dividing by two and then rounding toward minus infinity."
-msgstr "以下はビットパターンを1ビット左にシフトしてから右にシフトする例。この例で2進数パターンの下位ビットだけを示している。先行ビットは表示されている上位ビットにすべて一致する。確認できるように1ビットの左シフトは2を乗じて、右シフトは2で除してから負の無限大方向に丸められる。"
+msgstr "以下はビットパターンを1ビット左にシフトしてから右にシフトする例。この例で2進数パターンの下位ビットだけを示している。先頭ビットはすべて表示されている最上位ビットと一致する。ご覧のとおり1ビットの左シフトは2を乗ずること、1ビットの右シフトは2で除してから負の無限大方向に丸められることと等価である。"
 
 #. type: group
 #: original_texis/numbers.texi:909

--- a/lispref/numbers.texi.po
+++ b/lispref/numbers.texi.po
@@ -810,7 +810,7 @@ msgstr "Emacs Lispでは2つのfixnumが数値的に等しければ同一のLisp
 #. type: Plain text
 #: original_texis/numbers.texi:428
 msgid "Sometimes it is useful to compare numbers with @code{eql} or @code{equal}, which treat two numbers as equal if they have the same data type (both integers, or both floating point) and the same value.  By contrast, @code{=} can treat an integer and a floating-point number as equal.  @xref{Equality Predicates}."
-msgstr "数の比較において、2つの数が同じデータ型(どちらも整数か浮動小数)では、同じ値の場合は等しい数として扱う@code{eql}や@code{equal}のほうが便利なときもあります。対照的に@code{=}は整数と浮動小数点数を等しい数と扱うことができます。@ref{Equality Predicates}を参照してください。"
+msgstr "数の比較において、2つの数が同じデータ型(どちらも整数であるかどちらも浮動小数であるか)で同じ値の場合は等しい数として扱う@code{eql}や@code{equal}のほうが便利なときもあります。対照的に@code{=}は整数と浮動小数点数を(訳注:同じ値の場合には)等しい数と扱うことができます。@ref{Equality Predicates}を参照してください。"
 
 #. type: Plain text
 #: original_texis/numbers.texi:433

--- a/lispref/objects.texi.po
+++ b/lispref/objects.texi.po
@@ -2737,7 +2737,7 @@ msgstr "@dfn{バッファー(buffer)}とは、編集されるテキストを保�
 #. type: Plain text
 #: original_texis/objects.texi:1567
 msgid "The contents of a buffer are much like a string, but buffers are not used like strings in Emacs Lisp, and the available operations are different.  For example, you can insert text efficiently into an existing buffer, altering the buffer's contents, whereas inserting text into a string requires concatenating substrings, and the result is an entirely new string object."
-msgstr "バッファーの内容は文字列によく似ていますが、バッファーはEmacs Lispの文字列と同じようには使用されず、利用可能な操作は異なります。文字列にテキストを挿入するためには部分文字列の結合が必要で、結果は完全に新しい文字列オブジェクトなのるのにたいして、バッファーでは既存のバッファーに効率的にテキストを挿入してバッファーの内容を変更できます。"
+msgstr "バッファーの内容は文字列によく似ていますが、バッファーはEmacs Lispの文字列と同じようには使用されず、利用可能な操作は異なります。たとえば文字列にテキストを挿入するためには部分文字列の結合が必要であり、結果は完全に新しい文字列オブジェクトなのるのにたいして、バッファーでは既存のバッファーに効率的にテキストを挿入してバッファーの内容を変更できます。"
 
 #. type: Plain text
 #: original_texis/objects.texi:1571

--- a/lispref/objects.texi.po
+++ b/lispref/objects.texi.po
@@ -2420,7 +2420,7 @@ msgstr "primitive function"
 #. type: Plain text
 #: original_texis/objects.texi:1413
 msgid "A @dfn{primitive function} is a function callable from Lisp but written in the C programming language.  Primitive functions are also called @dfn{subrs} or @dfn{built-in functions}.  (The word ``subr'' is derived from ``subroutine''.)  Most primitive functions evaluate all their arguments when they are called.  A primitive function that does not evaluate all its arguments is called a @dfn{special form} (@pxref{Special Forms})."
-msgstr "@dfn{プリミティブ関数(primitive function)}とは、Cプログラミング言語で記述されたLispから呼び出せる関数です。プリミティブ関数は@dfn{subrs}や@dfn{ビルトイン関数(built-in functions)}とも呼ばれます(単語``subr''は``サブルーチン(subroutine)''が由来)。ほとんどのプリミティブ関数ハ、呼び出されたときニすべての引数を評価します。すべての引数を評価しないプリミティブ関数は@dfn{スペシャルフォーム(special form)}と呼ばれます(@ref{Special Forms}を参照)。"
+msgstr "@dfn{プリミティブ関数(primitive function)}とは、Cプログラミング言語で記述されたLispから呼び出せる関数です。プリミティブ関数は@dfn{subrs}や@dfn{ビルトイン関数(built-in functions)}とも呼ばれます(単語``subr''は``サブルーチン(subroutine)''が由来)。ほとんどのプリミティブ関数は、呼び出されたときにすべての引数を評価します。すべての引数を評価しないプリミティブ関数は@dfn{スペシャルフォーム(special form)}と呼ばれます(@ref{Special Forms}を参照)。"
 
 #. type: Plain text
 #: original_texis/objects.texi:1421

--- a/lispref/objects.texi.po
+++ b/lispref/objects.texi.po
@@ -960,7 +960,7 @@ msgstr "?Q @result{} 81     ?q @result{} 113\n"
 #. type: Plain text
 #: original_texis/objects.texi:377
 msgid "You can use the same syntax for punctuation characters.  However, if the punctuation character has a special syntactic meaning in Lisp, you must quote it with a @samp{\\}.  For example, @samp{?\\(} is the way to write the open-paren character.  Likewise, if the character is @samp{\\}, you must use a second @samp{\\} to quote it: @samp{?\\\\}."
-msgstr "区切り文字(punctuation characters)にも同じ構文を使用できますが、区切り文字がLispで特別な意味をもつ場合には@samp{\\\\}でクォートしなければなりません。たとえば@samp{?\\\\(}が開カッコを記述する方法であり、同様に文字が@samp{\\}なら、@samp{?\\\\}のようにクォートするために2つ目の@samp{\\}を使用しなければなりません。"
+msgstr "区切り文字(punctuation characters)にも同じ構文を使用できますが、区切り文字がLispで特別な意味をもつ場合には@samp{\\}でクォートしなければなりません。たとえば@samp{?\\(}が開カッコを記述する方法であり、同様に文字が@samp{\\}なら、@samp{?\\\\}のようにクォートするために2つ目の@samp{\\}を使用しなければなりません。"
 
 #. type: cindex
 #: original_texis/objects.texi:378

--- a/lispref/searching.texi.po
+++ b/lispref/searching.texi.po
@@ -885,7 +885,7 @@ msgstr "バッファーではなく文字列とマッチする際には、@samp{
 #. type: table
 #: original_texis/searching.texi:524
 msgid "For historical compatibility reasons, @samp{$} can be used only at the end of the regular expression, or before @samp{\\)} or @samp{\\|}."
-msgstr "歴史的な互換性という理由により@samp{$}は正規表現の先頭、または@samp{\\(}、@samp{\\(?:}、@samp{\\|}の前でのみ使用できる。"
+msgstr "歴史的な互換性という理由により@samp{$}は正規表現の終端、または@samp{\\)}、@samp{\\|}の前でのみ使用できる。"
 
 #. type: samp{#1}
 #: original_texis/searching.texi:525


### PR DESCRIPTION
emacs-28ブランチ，emacs-29ブランチへの変更と同じです．