### PR TITLE
thunkとは別のサブルーチン⇒thunkとは、別のサブルーチン

### DIFF
--- a/lispref/eval.texi.po
+++ b/lispref/eval.texi.po
@@ -1726,7 +1726,7 @@ msgstr "thunk-delay forms@dots{}"
 #. type: defmac
 #: original_texis/eval.texi:930
 msgid "Return a @dfn{thunk} for evaluating the @var{forms}.  A thunk is a closure (@pxref{Closures}) that inherits the lexical environment of the @code{thunk-delay} call.  Using this macro requires @code{lexical-binding}."
-msgstr "@var{forms}を評価するための@dfn{thunk}をリターンする(訳注: thunkとは別のサブルーチンに計算を追加で挿入するために使用するサブルーチンであり、計算結果が必要になるまで計算を遅延したり、別のサブルーチンの先頭や最後に処理を挿入するために使用される。英語版Wikipediaより)。thunkは@code{thunk-delay}呼び出しのlexical環境を継承するクロージャである(@ref{Closures}を参照)。このマクロの使用には@code{lexical-binding}が必要。"
+msgstr "@var{forms}を評価するための@dfn{thunk}をリターンする(訳注: thunkとは、別のサブルーチンに計算を追加で挿入するために使用するサブルーチンであり、計算結果が必要になるまで計算を遅延したり、別のサブルーチンの先頭や最後に処理を挿入するために使用される。英語版Wikipediaより)。thunkは@code{thunk-delay}呼び出しのlexical環境を継承するクロージャである(@ref{Closures}を参照)。このマクロの使用には@code{lexical-binding}が必要。"
 
 #. type: defun
 #: original_texis/eval.texi:932

--- a/lispref/eval.texi.po
+++ b/lispref/eval.texi.po
@@ -1709,7 +1709,7 @@ msgstr "lazy evaluation"
 #. type: Plain text
 #: original_texis/eval.texi:923
 msgid "Sometimes it is useful to delay the evaluation of an expression, for example if you want to avoid performing a time-consuming calculation if it turns out that the result is not needed in the future of the program.  The @file{thunk} library provides the following functions and macros to support such @dfn{deferred evaluation}:"
-msgstr "たとえばプログラムの将来において計算結果が不要なら時間を要する計算処理を回避したい等、式の評価を遅延できれば便利な場合があります。そのような@dfn{遅延評価(deferred evaluation)}をサポートするために、@file{thunk}は以下の関数とマクロを提供します。"
+msgstr "たとえばプログラムの将来において計算結果が不要ということがわかった場合に時間を要する計算処理を回避したい等、式の評価を遅延させると便利な場合があります。そのような@dfn{遅延評価(deferred evaluation)}をサポートするために、@file{thunk}は以下の関数とマクロを提供します。"
 
 #. type: cindex
 #: original_texis/eval.texi:924

--- a/lispref/eval.texi.po
+++ b/lispref/eval.texi.po
@@ -1271,7 +1271,7 @@ msgstr "@code{quote}と同じです。"
 #. type: ifnottex
 #: original_texis/eval.texi:636
 msgid "@code{quote} (described in the previous section; @pxref{Quoting})."
-msgstr "@code{quote} (前セクションで説明済み。@ref{Quoting}を参照)。"
+msgstr "@code{quote} (前セクションで説明済み。@ref{Quoting}を参照)と同じになります。"
 
 #. type: Plain text
 #: original_texis/eval.texi:638

--- a/lispref/eval.texi.po
+++ b/lispref/eval.texi.po
@@ -1261,7 +1261,7 @@ msgstr "forms, backquote"
 #. type: Plain text
 #: original_texis/eval.texi:630
 msgid "@dfn{Backquote constructs} allow you to quote a list, but selectively evaluate elements of that list.  In the simplest case, it is identical to the special form"
-msgstr "@dfn{バッククォート構文(backquote constructs)}を使用することにより、リストをクォートしてそのリストのある要素を選択的に評価することができます。もっとも簡単な使い方ではスペシャルフォーム"
+msgstr "@dfn{バッククォート構文(backquote constructs)}を使用することにより、リストをクォートしてそのリストのある要素を選択的に評価することができます。もっとも単純な場合、スペシャルフォーム"
 
 #. type: iftex
 #: original_texis/eval.texi:632


### PR DESCRIPTION
読点がないと「thunkというサブルーチンもあるがそれとは別のサブルーチン」という風に読めてしまうので，読点を追加しました．