### PR TITLE
区切り文字"文字と\クォートなしで⇒"文字や\クォートで区切ることなく

### DIFF
--- a/lispref/customize.texi.po
+++ b/lispref/customize.texi.po
@@ -1164,7 +1164,7 @@ msgstr "string"
 #. type: table
 #: original_texis/customize.texi:617
 msgid "The value must be a string.  The customization buffer shows the string without delimiting @samp{\"} characters or @samp{\\} quotes."
-msgstr "値は文字列でなければならない。カスタマイゼーションバッファーはその文字列を区切り文字@samp{\"}文字と@samp{\\}クォートなしで表示する。"
+msgstr "値は文字列でなければならない。カスタマイゼーションバッファーはその文字列を@samp{\"}文字や@samp{\\}クォートで区切ることなく表示する。"
 
 #. type: item
 #: original_texis/customize.texi:618


### PR DESCRIPTION
訳を変えてみました．