### PR TITLE
行ても⇒しても

### DIFF
--- a/lispref/customize.texi.po
+++ b/lispref/customize.texi.po
@@ -635,7 +635,7 @@ msgstr "@code{defvar}と同様、このマクロは@code{option}をスペシャ�
 #. type: defmac
 #: original_texis/customize.texi:322
 msgid "The expression @var{standard} can be evaluated at various other times, too---whenever the customization facility needs to know @var{option}'s standard value.  So be sure to use an expression which is harmless to evaluate at any time."
-msgstr "式@var{standard}は別の様々な機会 --- カスタマイゼーション機能が@var{option}の標準値を知る必要があるときは常に --- にも評価される可能性がある。そのため任意回数の評価を行ても安全な式を使用するように留意されたい。"
+msgstr "式@var{standard}は別の様々な機会 --- カスタマイゼーション機能が@var{option}の標準値を知る必要があるときは常に --- にも評価される可能性がある。そのため任意回数の評価をしても安全な式を使用するように留意されたい。"
 
 #. type: defmac
 #: original_texis/customize.texi:325

--- a/lispref/customize.texi.po
+++ b/lispref/customize.texi.po
@@ -1923,7 +1923,7 @@ msgstr "型構築の引数として@var{argument-list}の要素を使用する�
 #. type: Plain text
 #: original_texis/customize.texi:1048
 msgid "The @code{:inline} feature lets you splice a variable number of elements into the middle of a @code{list} or @code{vector} customization type.  You use it by adding @code{:inline t} to a type specification which is contained in a @code{list} or @code{vector} specification."
-msgstr "@code{:inline}機能により可変個の要素を、カスタマイゼーション型の@code{list}や@code{vector}の途中にスプライス(splice: 継ぎ足す)することができます。@code{list}や@code{vector}記述を含む型にたいして@code{:inline t}を追加することによってこれを使用します。"
+msgstr "@code{:inline}機能により可変個の要素を、カスタマイゼーション型の@code{list}や@code{vector}の途中にスプライス(splice: 継ぎ足す)することができます。@code{list}や@code{vector}に含まれる型の仕様にたいして@code{:inline t}を追加することによってこれを使用します。"
 
 #. type: Plain text
 #: original_texis/customize.texi:1056

--- a/lispref/customize.texi.po
+++ b/lispref/customize.texi.po
@@ -1405,7 +1405,7 @@ msgstr "値は@var{element-types}で与えられる要素と数が正確に一�
 #. type: table
 #: original_texis/customize.texi:731
 msgid "For example, @code{(list integer string function)} describes a list of three elements; the first element must be an integer, the second a string, and the third a function."
-msgstr "たとえば@code{(list integer string function)}は3つの要素のリストを示し、1つ目の要素は整数、2つ目の要素は文字列、3つ目の要素は関数である。"
+msgstr "たとえば@code{(list integer string function)}は3つの要素のリストを示し、1つ目の要素は整数、2つ目の要素は文字列、3つ目の要素は関数でなければならない。"
 
 #. type: table
 #: original_texis/customize.texi:734

--- a/lispref/customize.texi.po
+++ b/lispref/customize.texi.po
@@ -2247,7 +2247,7 @@ msgstr "help-echo@r{, customization keyword}"
 #. type: table
 #: original_texis/customize.texi:1201
 msgid "When you move to this item with @code{widget-forward} or @code{widget-backward}, it will display the string @var{motion-doc} in the echo area.  In addition, @var{motion-doc} is used as the mouse @code{help-echo} string and may actually be a function or form evaluated to yield a help string.  If it is a function, it is called with one argument, the widget."
-msgstr "@code{widget-forward}や@code{widget-backward}でこのアイテムに移動したときに、エコーエリアに文字列@var{motion-doc}を表示する。さらにマウスの@code{help-echo}文字列として@var{motion-doc}が使用され、これには実際には」ヘルプ文字列を生成するために評価される関数かフォームを指定できる。もし関数ならそれは1つの引数(そのウィジェット)で呼び出される。"
+msgstr "@code{widget-forward}や@code{widget-backward}でこのアイテムに移動したときに、エコーエリアに文字列@var{motion-doc}を表示する。さらにマウスの@code{help-echo}文字列として@var{motion-doc}が使用され、それは実際にはヘルプ文字列を生成するために評価される関数かフォームである可能性がある。もし関数ならそれは1つの引数(そのウィジェット)で呼び出される。"
 
 #. type: item
 #: original_texis/customize.texi:1202

--- a/lispref/customize.texi.po
+++ b/lispref/customize.texi.po
@@ -2427,7 +2427,7 @@ msgstr "define new customization types"
 #. type: Plain text
 #: original_texis/customize.texi:1307
 msgid "In the previous sections we have described how to construct elaborate type specifications for @code{defcustom}.  In some cases you may want to give such a type specification a name.  The obvious case is when you are using the same type for many user options: rather than repeat the specification for each option, you can give the type specification a name, and use that name each @code{defcustom}.  The other case is when a user option's value is a recursive data structure.  To make it possible for a datatype to refer to itself, it needs to have a name."
-msgstr "前のセクションでは、@code{defcustom}にたいして型の詳細な仕様を作成する方法を説明しました。そのような型仕様に名前を与えたい場合があるかもしれません。理解しやすいケースとしては、多くのユーザーオプションに同じ型を使用する場合などです。各オプションにたいして仕様を繰り返すよりその型に名前を与えて、@code{defcustom}それぞれにその名前を使用することができます。他にもユーザーオプションの値が再帰的なデータ構造のケースがあります。あるデータ型がそれ自身を参照できるようにするためには、それが名前をもつ必要があります。"
+msgstr "前のセクションでは、@code{defcustom}にたいして型の詳細な仕様を作成する方法を説明しました。そのような型仕様に名前を与えたい場合があるかもしれません。理解しやすいケースとしては、多くのユーザーオプションに同じ型を使用する場合などです。各オプションにたいして仕様を繰り返すのではなく、その型に名前を与えて、@code{defcustom}それぞれにその名前を使用することができます。他にもユーザーオプションの値が再帰的なデータ構造のケースがあります。あるデータ型がそれ自身を参照できるようにするためには、それが名前をもつ必要があります。"
 
 #. type: Plain text
 #: original_texis/customize.texi:1314

--- a/lispref/customize.texi.po
+++ b/lispref/customize.texi.po
@@ -1972,7 +1972,7 @@ msgstr ""
 #. type: Plain text
 #: original_texis/customize.texi:1087
 msgid "If the user chooses the first alternative in the choice, then the overall list has two elements and the second element is @code{t}.  If the user chooses the second alternative, then the overall list has three elements and the second and third must be strings."
-msgstr "選択においてユーザーが選択肢の1つ目を選んだ場合はリスト全体が2つの要素をもち、2つ目の要素は@code{t}になります。ユーザーが2つ目の候補を選んだ場合にはリスト全体が3つの要素をもち、2つ目と3つ目の要素は文字列でなければなりません。"
+msgstr "選択においてユーザーが選択肢の1つ目を選んだ場合はリスト全体が2つの要素をもち、2つ目の要素は@code{t}になります。ユーザーが2つ目の選択肢を選んだ場合にはリスト全体が3つの要素をもち、2つ目と3つ目の要素は文字列でなければなりません。"
 
 #. type: Plain text
 #: original_texis/customize.texi:1090

--- a/lispref/customize.texi.po
+++ b/lispref/customize.texi.po
@@ -1164,7 +1164,7 @@ msgstr "string"
 #. type: table
 #: original_texis/customize.texi:617
 msgid "The value must be a string.  The customization buffer shows the string without delimiting @samp{\"} characters or @samp{\\} quotes."
-msgstr "値は文字列でなければならない。カスタマイゼーションバッファーはその文字列を区切り文字@samp{\"}文字と@samp{\\}クォートなしで表示する。"
+msgstr "値は文字列でなければならない。カスタマイゼーションバッファーはその文字列を@samp{\"}文字や@samp{\\}クォートで区切ることなく表示する。"
 
 #. type: item
 #: original_texis/customize.texi:618


### PR DESCRIPTION
typo: 修正案は「しても」ですが「行っても」に修正する方法もあります．